### PR TITLE
Remove afrofuturism from Lilith's brood

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -777,7 +777,7 @@
               <div class="item-content">
                 <h3 class="item-title">Lilith's Brood</h3>
                 <p class="item-author">by Octavia E. Butler</p>
-                <p class="item-category">Science Fiction/Afrofuturism</p>
+                <p class="item-category">Science Fiction</p>
                 <p class="item-description">A groundbreaking science fiction trilogy that explores themes of human evolution, alien contact, and the nature of humanity itself. The series follows Lilith Iyapo and her descendants as they navigate a post-apocalyptic world where humans must choose between extinction and genetic transformation through contact with an alien species.</p>
               </div>
               <div class="item-actions">


### PR DESCRIPTION
Remove "Afrofuturism" from Lilith's Brood category as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-040d8d3c-1052-4e24-ad1b-0eca56456b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-040d8d3c-1052-4e24-ad1b-0eca56456b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

