### PR TITLE
Add plato's five dialogues to notable books

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -689,6 +689,18 @@
                 <a href="https://share.google/xO3Vx3sYrAo6wvMch" class="item-link" target="_blank" rel="noopener">View</a>
               </div>
             </div>
+
+            <div class="notable-item">
+              <div class="item-content">
+                <h3 class="item-title">Five Dialogues</h3>
+                <p class="item-author">by Plato</p>
+                <p class="item-category">Philosophy/Classical Literature</p>
+                <p class="item-description">A collection of five essential dialogues by the ancient Greek philosopher Plato, including Euthyphro, Apology, Crito, Meno, and Phaedo. These foundational works explore fundamental questions about virtue, justice, knowledge, and the nature of the soul, presenting Socrates' method of inquiry and his philosophical legacy through Plato's masterful writing.</p>
+              </div>
+              <div class="item-actions">
+                <a href="https://www.amazon.com/Five-Dialogues-Plato/dp/0872206335" class="item-link" target="_blank" rel="noopener">View</a>
+              </div>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
Add 'Plato's Five Dialogues' to the Nonfiction Books section of notable books.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cd8bd18-4081-416b-bef3-12a63d89b924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cd8bd18-4081-416b-bef3-12a63d89b924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

