### PR TITLE
Add Wikimedia Foundation to notable organizations

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -912,6 +912,23 @@
           </div>
         </section>
 
+        <!-- Organizations Section -->
+        <section class="notable-section">
+          <h2 class="section-title">Organizations</h2>
+          <div class="section-content">
+            <div class="notable-item">
+              <div class="item-content">
+                <h3 class="item-title">Wikimedia Foundation, Inc.</h3>
+                <p class="item-category">Nonprofit Organization</p>
+                <p class="item-description">Wikimedia Foundation, Inc. (WMF) is an American 501(c)(3) nonprofit organization headquartered in San Francisco, California, and operates Wikipedia and other free knowledge projects. The foundation supports the development of free, open educational content and promotes the growth of free knowledge worldwide.</p>
+              </div>
+              <div class="item-actions">
+                <a href="https://wikimediafoundation.org/" class="item-link" target="_blank" rel="noopener">Visit</a>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <!-- Music & Media Section -->
         <section class="notable-section">
           <h2 class="section-title">Music & Media</h2>


### PR DESCRIPTION
Add Wikimedia Foundation, Inc. to a new 'Organizations' section on the notable page.

---
<a href="https://cursor.com/background-agent?bcId=bc-15491233-92ab-43cf-bc1a-48f277dae908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15491233-92ab-43cf-bc1a-48f277dae908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

