### PR TITLE
Add vlc media player to notable things

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -31,7 +31,7 @@
               <span class="section-title-toggle">▼</span>
               <span>Tools & Services</span>
             </span>
-              <span class="section-title-count">6</span><!-- UPDATE THIS COUNT when adding/removing items -->
+              <span class="section-title-count">7</span><!-- UPDATE THIS COUNT when adding/removing items -->
           </h2>
           <div class="section-content">
             <div class="notable-item">
@@ -86,6 +86,17 @@
                 </div>
                 <div class="item-actions">
                   <a href="https://github.com/odlp/bluesnooze" class="item-link" target="_blank" rel="noopener">Visit</a>
+                </div>
+              </div>
+
+              <div class="notable-item">
+                <div class="item-content">
+                  <h3 class="item-title">VLC media player</h3>
+                  <p class="item-category">Media Player</p>
+                  <p class="item-description">Open-source, cross-platform multimedia player supporting a wide range of formats, streaming protocols, and customizations without extra codecs.</p>
+                </div>
+                <div class="item-actions">
+                  <a href="https://www.videolan.org/vlc/" class="item-link" target="_blank" rel="noopener">Visit</a>
                 </div>
               </div>
 


### PR DESCRIPTION
Add VLC media player to the "Tools & Services" section of the notable things page and update the section count.

---
<a href="https://cursor.com/background-agent?bcId=bc-eda8b0cc-5abd-4d3d-bd5b-f3b9e81ae5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eda8b0cc-5abd-4d3d-bd5b-f3b9e81ae5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

