### PR TITLE
Remove introductory paragraph from values page

### DIFF
--- a/values.html
+++ b/values.html
@@ -27,8 +27,6 @@
 
       <div class="about-content-wrapper">
         <div class="about-content">
-          <p>I am writing this to intentionally and publicly document some of my own principles, to inform friends and collaborators, and (in this very small way) contribute to social discussion.</p>
-          
           <p>I am inspired by the <a href="https://www.hrc.org/resources/transgender-and-non-binary-faq" target="_blank" rel="noopener">Human Rights Campaign's</a> guidance on sharing pronouns:</p>
 
           <blockquote class="quote-block" style="margin: 2rem 0;">


### PR DESCRIPTION
## Summary
Removed the introductory paragraph from the values page to streamline the content and lead directly with the pronouns guidance section.

## Changes
- Removed the opening paragraph that explained the purpose of documenting personal principles
- Removed the associated blank line for cleaner formatting
- The pronouns guidance section now appears as the first content after the page heading

## Rationale
This change simplifies the values page by removing meta-commentary about the page itself and allowing readers to immediately engage with the substantive content about pronouns and inclusivity.

https://claude.ai/code/session_01LFLxSKSAdFmEDue8pktr87