### PR TITLE
Increase max-height limit for expandable content container

### DIFF
--- a/notable.css
+++ b/notable.css
@@ -161,7 +161,7 @@ body[data-theme="dark"] {
   align-items: stretch;
   grid-auto-rows: 1fr;
   margin-top: 1rem;
-  max-height: 5000px;
+  max-height: 20000px;
   overflow: hidden;
   transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
   opacity: 1;


### PR DESCRIPTION
## Summary
Increased the maximum height constraint for an expandable content container from 5000px to 20000px to accommodate larger content displays.

## Changes
- Updated `.notable-css` max-height property from `5000px` to `20000px` for the grid container with transition animations

## Details
This change allows the container to expand to a greater height when needed, while maintaining the existing smooth transition animations (0.3s ease). The overflow is still hidden, so content will be clipped if it exceeds the new limit, but this provides significantly more room for expanded content before truncation occurs.

https://claude.ai/code/session_013kLcb5EZcjZmBVxQY6akrw