### PR TITLE
Stack nav buttons vertically on mobile instead of wrapping

### DIFF
--- a/style.css
+++ b/style.css
@@ -385,11 +385,15 @@ footer a:hover {
   .centerpiece-links {
     bottom: 1rem;
     padding: 0 1rem;
-    gap: 0.75rem;
+    gap: 0.5rem;
+    flex-direction: column;
+    align-items: center;
   }
   .centerpiece-links .btn {
     font-size: 0.9rem;
     padding: 0.5rem 1rem;
+    min-width: 140px;
+    text-align: center;
   }
   .dropdown-menu {
     min-width: 120px;


### PR DESCRIPTION
When the viewport is narrow, the four homepage buttons (About, Timeline,
Notable, Projects) now stack in a vertical column rather than wrapping
unevenly across rows.

https://claude.ai/code/session_01H3GVvGHfAYHgdUG1iywNiN