### PR TITLE
Add Music Albums and Music Artists sections to notable page

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -19,7 +19,7 @@
     <main class="notable-main">
       <header class="notable-header">
         <h1>Notable</h1>
-        <p class="notable-subtitle">Products, services, books, and tools worth noting</p>
+        <p class="notable-subtitle">Products, services, books, music, and tools worth noting</p>
       </header>
 
       <div class="notable-grid">
@@ -742,6 +742,411 @@
                 <a href="https://rainflow.523.life/" class="item-link" target="_blank" rel="noopener">rainflow.523.life</a>
               </div>
             </div>
+          </div>
+        </section>
+
+        <!-- Music Albums Section -->
+        <!-- IMPORTANT: When adding/removing items, update the count in section-title-count below -->
+        <section class="notable-section">
+          <h2 class="section-title">
+            <span class="section-title-text">
+              <span class="section-title-toggle">▼</span>
+              <span>Music Albums</span>
+            </span>
+            <span class="section-title-count">59</span><!-- UPDATE THIS COUNT when adding/removing items -->
+          </h2>
+          <div class="section-content">
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Sparkle and Fade</h3>
+                <p class="item-author">by Everclear</p>
+                <p class="item-category">Alternative Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">A/B</h3>
+                <p class="item-author">by Kaleo</p>
+                <p class="item-category">Blues Rock / Alternative</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Mind Control Acoustic</h3>
+                <p class="item-author">by Stephen Marley</p>
+                <p class="item-category">Reggae / Acoustic</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">No Jacket Required</h3>
+                <p class="item-author">by Phil Collins</p>
+                <p class="item-category">Pop Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Kickin' It</h3>
+                <p class="item-author">by Hamilton Loomis</p>
+                <p class="item-category">Blues</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Eat Ya Veggies</h3>
+                <p class="item-author">by bbno$</p>
+                <p class="item-category">Hip Hop / Pop</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Freaks of Nature</h3>
+                <p class="item-author">by Drain STH</p>
+                <p class="item-category">Alternative Metal</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Jagged Little Pill</h3>
+                <p class="item-author">by Alanis Morissette</p>
+                <p class="item-category">Alternative Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">John Coltrane and Johnny Hartman</h3>
+                <p class="item-author">by John Coltrane and Johnny Hartman</p>
+                <p class="item-category">Jazz</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Greatest Hits</h3>
+                <p class="item-author">by Steve Miller Band</p>
+                <p class="item-category">Classic Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">ZABA</h3>
+                <p class="item-author">by Glass Animals</p>
+                <p class="item-category">Psychedelic Pop / Indie</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">A 20 Something Fuck</h3>
+                <p class="item-author">by Two Feet</p>
+                <p class="item-category">Electronic / Blues</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">The Hits / The B-Sides</h3>
+                <p class="item-author">by Prince</p>
+                <p class="item-category">Pop / Funk / R&amp;B</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Don't Explain</h3>
+                <p class="item-author">by Beth Hart and Joe Bonamassa</p>
+                <p class="item-category">Blues / Soul</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Mescalito</h3>
+                <p class="item-author">by Ryan Bingham</p>
+                <p class="item-category">Americana / Country Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Swimming</h3>
+                <p class="item-author">by Mac Miller</p>
+                <p class="item-category">Hip Hop / R&amp;B</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Live at Bonnaroo</h3>
+                <p class="item-author">by Warren Haynes</p>
+                <p class="item-category">Blues Rock / Southern Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Tapestry</h3>
+                <p class="item-author">by Carole King</p>
+                <p class="item-category">Singer-Songwriter / Pop</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">The Razors Edge</h3>
+                <p class="item-author">by AC/DC</p>
+                <p class="item-category">Hard Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Nothing But the Best</h3>
+                <p class="item-author">by Frank Sinatra</p>
+                <p class="item-category">Vocal Jazz / Standards</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Trouble</h3>
+                <p class="item-author">by Ray LaMontagne</p>
+                <p class="item-category">Folk / Singer-Songwriter</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Facelift</h3>
+                <p class="item-author">by Alice in Chains</p>
+                <p class="item-category">Grunge / Metal</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Violator</h3>
+                <p class="item-author">by Depeche Mode</p>
+                <p class="item-category">Synth-Pop / Electronic</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Nowhere to Hide</h3>
+                <p class="item-author">by The Virus</p>
+                <p class="item-category">Street Punk</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Destruction by Definition</h3>
+                <p class="item-author">by The Suicide Machines</p>
+                <p class="item-category">Ska Punk</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Live at the Old Quarter</h3>
+                <p class="item-author">by Townes Van Zandt</p>
+                <p class="item-category">Folk / Country</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Moving Pictures</h3>
+                <p class="item-author">by Rush</p>
+                <p class="item-category">Progressive Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">2112</h3>
+                <p class="item-author">by Rush</p>
+                <p class="item-category">Progressive Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Retrospective I &amp; II</h3>
+                <p class="item-author">by Rush</p>
+                <p class="item-category">Progressive Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Rock Spectacle</h3>
+                <p class="item-author">by Barenaked Ladies</p>
+                <p class="item-category">Alternative Rock / Live</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Let It Be Me</h3>
+                <p class="item-author">by Nina Simone</p>
+                <p class="item-category">Jazz / Soul</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Rainbow</h3>
+                <p class="item-author">by Kesha</p>
+                <p class="item-category">Pop</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Lie to Me</h3>
+                <p class="item-author">by Jonny Lang</p>
+                <p class="item-category">Blues Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Live at the Regal</h3>
+                <p class="item-author">by B.B. King</p>
+                <p class="item-category">Blues</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Who Killed the Zutons</h3>
+                <p class="item-author">by The Zutons</p>
+                <p class="item-category">Indie Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Heartattack and Vine</h3>
+                <p class="item-author">by Tom Waits</p>
+                <p class="item-category">Blues Rock / Experimental</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Hell Freezes Over</h3>
+                <p class="item-author">by Eagles</p>
+                <p class="item-category">Rock / Country Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Keep 'Em on They Toes</h3>
+                <p class="item-author">by Brent Cobb</p>
+                <p class="item-category">Country / Americana</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Rage Against the Machine</h3>
+                <p class="item-author">by Rage Against the Machine</p>
+                <p class="item-category">Rap Metal / Alternative</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Grace</h3>
+                <p class="item-author">by Jeff Buckley</p>
+                <p class="item-category">Alternative Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">The Emancipation of Mimi</h3>
+                <p class="item-author">by Mariah Carey</p>
+                <p class="item-category">R&amp;B / Pop</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Traveller</h3>
+                <p class="item-author">by Chris Stapleton</p>
+                <p class="item-category">Country / Southern Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Metamodern Sounds in Country Music</h3>
+                <p class="item-author">by Sturgill Simpson</p>
+                <p class="item-category">Country / Psychedelic</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">No Fences</h3>
+                <p class="item-author">by Garth Brooks</p>
+                <p class="item-category">Country</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Pieces of You</h3>
+                <p class="item-author">by Jewel</p>
+                <p class="item-category">Folk / Singer-Songwriter</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">The Boatman's Call</h3>
+                <p class="item-author">by Nick Cave and the Bad Seeds</p>
+                <p class="item-category">Alternative / Art Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Unplugged</h3>
+                <p class="item-author">by Eric Clapton</p>
+                <p class="item-category">Acoustic / Blues</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Whitey Ford Sings the Blues</h3>
+                <p class="item-author">by Everlast</p>
+                <p class="item-category">Hip Hop / Blues Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Sublime</h3>
+                <p class="item-author">by Sublime</p>
+                <p class="item-category">Ska Punk / Reggae Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Bedtime Stories</h3>
+                <p class="item-author">by Madonna</p>
+                <p class="item-category">Pop / R&amp;B</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Endless Summer Vacation</h3>
+                <p class="item-author">by Miley Cyrus</p>
+                <p class="item-category">Pop / Dance</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Where Have All the Merrymakers Gone?</h3>
+                <p class="item-author">by Harvey Danger</p>
+                <p class="item-category">Alternative Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Metallica (Black Album)</h3>
+                <p class="item-author">by Metallica</p>
+                <p class="item-category">Heavy Metal / Hard Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">The River</h3>
+                <p class="item-author">by Bruce Springsteen</p>
+                <p class="item-category">Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Texas Flood</h3>
+                <p class="item-author">by Stevie Ray Vaughan</p>
+                <p class="item-category">Blues Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">No More Tears</h3>
+                <p class="item-author">by Ozzy Osbourne</p>
+                <p class="item-category">Heavy Metal</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Boston</h3>
+                <p class="item-author">by Boston</p>
+                <p class="item-category">Classic Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Dookie</h3>
+                <p class="item-author">by Green Day</p>
+                <p class="item-category">Pop Punk</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Give Me Convenience or Give Me Death</h3>
+                <p class="item-author">by Dead Kennedys</p>
+                <p class="item-category">Hardcore Punk</p>
+              </div></a>
+          </div>
+        </section>
+
+        <!-- Music Artists Section -->
+        <!-- IMPORTANT: When adding/removing items, update the count in section-title-count below -->
+        <section class="notable-section">
+          <h2 class="section-title">
+            <span class="section-title-text">
+              <span class="section-title-toggle">▼</span>
+              <span>Music Artists</span>
+            </span>
+            <span class="section-title-count">5</span><!-- UPDATE THIS COUNT when adding/removing items -->
+          </h2>
+          <div class="section-content">
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Chris Stapleton</h3>
+                <p class="item-category">Country / Southern Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Rush</h3>
+                <p class="item-category">Progressive Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">John Mellencamp</h3>
+                <p class="item-category">Heartland Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Gov't Mule</h3>
+                <p class="item-category">Southern Rock / Blues Rock</p>
+              </div></a>
+
+            <a href="#" class="notable-item"><div class="item-content">
+                <h3 class="item-title">Tantric</h3>
+                <p class="item-category">Post-Grunge / Alternative Rock</p>
+              </div></a>
           </div>
         </section>
 


### PR DESCRIPTION
Add 59 music albums and 5 music artists as new notable categories,
covering genres from blues and jazz to punk, country, and electronic.
Update page subtitle to include music.

https://claude.ai/code/session_01W6ofQM1nt7CH74tPQuYnRj