### PR TITLE
Refactor centerpiece links layout for mobile responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -385,17 +385,21 @@ footer a:hover {
     padding: 0.6rem 1.1rem;
   }
   .centerpiece-links {
-    bottom: 1rem;
+    bottom: 0.75rem;
     padding: 0 1rem;
-    gap: 0.5rem;
-    flex-direction: column;
+    gap: 0.4rem;
+    flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
   }
   .centerpiece-links .btn {
-    font-size: 0.9rem;
-    padding: 0.5rem 1rem;
-    min-width: 140px;
+    font-size: 0.8rem;
+    padding: 0.35rem 0.6rem;
+    width: calc(50% - 0.2rem);
     text-align: center;
+    box-sizing: border-box;
+    min-width: 0;
   }
   .dropdown-menu {
     min-width: 120px;


### PR DESCRIPTION
## Summary
Updated the centerpiece links styling to use a responsive two-column grid layout instead of a vertical stack, with adjusted spacing and sizing for better mobile display.

## Key Changes
- Changed flex direction from `column` to `row` with `flex-wrap: wrap` for horizontal layout
- Adjusted button sizing: reduced font size (0.9rem → 0.8rem) and padding (0.5rem 1rem → 0.35rem 0.6rem)
- Implemented two-column layout using `width: calc(50% - 0.2rem)` with `box-sizing: border-box`
- Reduced gap between items (0.5rem → 0.4rem) and bottom spacing (1rem → 0.75rem)
- Added `justify-content: center` for proper horizontal alignment
- Removed fixed `min-width: 140px` constraint and replaced with `min-width: 0` to allow flexible sizing

## Implementation Details
The layout now displays buttons in a 2-column grid on mobile devices with proper wrapping behavior. The width calculation accounts for the gap spacing to prevent overflow, and `box-sizing: border-box` ensures padding is included in the width calculation.

https://claude.ai/code/session_014qKdyyw2KprEbSaTG5btzs