### PR TITLE
Add album art and artist images to music sections

### DIFF
--- a/.github/workflows/fetch-music-images.yml
+++ b/.github/workflows/fetch-music-images.yml
@@ -1,0 +1,47 @@
+name: Fetch Music Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - notable.html
+
+jobs:
+  fetch-images:
+    # Don't run on commits made by this workflow itself
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so we can push back
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Generate SVG placeholders for any new items
+        run: python3 generate_placeholder_images.py
+
+      - name: Fetch real album art and artist images
+        run: python3 fetch_music_images.py
+
+      - name: Commit and push any new images
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add images/albums/ images/artists/ notable.html
+          if git diff --cached --quiet; then
+            echo "No new images to commit."
+          else
+            git commit -m "chore: fetch music images for updated notable.html [skip ci]"
+            git push origin main
+          fi

--- a/fetch_music_images.py
+++ b/fetch_music_images.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Fetch album art from MusicBrainz Cover Art Archive and artist images from Wikipedia.
+Downloads images to images/albums/ and images/artists/, then updates notable.html.
+
+Usage: python3 fetch_music_images.py
+"""
+
+import os
+import re
+import time
+import json
+import urllib.request
+import urllib.parse
+import urllib.error
+
+USER_AGENT = "523.life-music-images/1.0 (https://523.life)"
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Albums: (html_title, artist, optional_search_title)
+# optional_search_title used when HTML title differs from MusicBrainz title
+ALBUMS = [
+    ("Sparkle and Fade", "Everclear", None),
+    ("A/B", "Kaleo", None),
+    ("Mind Control Acoustic", "Stephen Marley", None),
+    ("No Jacket Required", "Phil Collins", None),
+    ("Kickin' It", "Hamilton Loomis", None),
+    ("Eat Ya Veggies", "bbno$", None),
+    ("Freaks of Nature", "Drain STH", None),
+    ("Jagged Little Pill", "Alanis Morissette", None),
+    ("John Coltrane and Johnny Hartman", "John Coltrane", None),
+    ("Greatest Hits", "Steve Miller Band", None),
+    ("ZABA", "Glass Animals", None),
+    ("A 20 Something Fuck", "Two Feet", None),
+    ("The Hits / The B-Sides", "Prince", "The Hits/The B-Sides"),
+    ("Don't Explain", "Beth Hart", None),
+    ("Mescalito", "Ryan Bingham", None),
+    ("Swimming", "Mac Miller", None),
+    ("Live at Bonnaroo", "Warren Haynes", None),
+    ("Tapestry", "Carole King", None),
+    ("The Razors Edge", "AC/DC", None),
+    ("Nothing But the Best", "Frank Sinatra", None),
+    ("Trouble", "Ray LaMontagne", None),
+    ("Facelift", "Alice in Chains", None),
+    ("Violator", "Depeche Mode", None),
+    ("Nowhere to Hide", "The Virus", None),
+    ("Destruction by Definition", "The Suicide Machines", None),
+    ("Live at the Old Quarter", "Townes Van Zandt", None),
+    ("Moving Pictures", "Rush", None),
+    ("2112", "Rush", None),
+    ("Retrospective I & II", "Rush", "Retrospective I & II"),
+    ("Rock Spectacle", "Barenaked Ladies", None),
+    ("Let It Be Me", "Nina Simone", None),
+    ("Rainbow", "Kesha", None),
+    ("Lie to Me", "Jonny Lang", None),
+    ("Live at the Regal", "B.B. King", None),
+    ("Who Killed the Zutons", "The Zutons", None),
+    ("Heartattack and Vine", "Tom Waits", None),
+    ("Hell Freezes Over", "Eagles", None),
+    ("Keep 'Em on They Toes", "Brent Cobb", None),
+    ("Rage Against the Machine", "Rage Against the Machine", None),
+    ("Grace", "Jeff Buckley", None),
+    ("The Emancipation of Mimi", "Mariah Carey", None),
+    ("Traveller", "Chris Stapleton", None),
+    ("Metamodern Sounds in Country Music", "Sturgill Simpson", None),
+    ("No Fences", "Garth Brooks", None),
+    ("Pieces of You", "Jewel", None),
+    ("The Boatman's Call", "Nick Cave and the Bad Seeds", None),
+    ("Unplugged", "Eric Clapton", None),
+    ("Whitey Ford Sings the Blues", "Everlast", None),
+    ("Sublime", "Sublime", None),
+    ("Bedtime Stories", "Madonna", None),
+    ("Endless Summer Vacation", "Miley Cyrus", None),
+    ("Where Have All the Merrymakers Gone?", "Harvey Danger", None),
+    ("Metallica (Black Album)", "Metallica", "Metallica"),
+    ("The River", "Bruce Springsteen", None),
+    ("Texas Flood", "Stevie Ray Vaughan", None),
+    ("No More Tears", "Ozzy Osbourne", None),
+    ("Boston", "Boston", None),
+    ("Dookie", "Green Day", None),
+    ("Give Me Convenience or Give Me Death", "Dead Kennedys", None),
+    ("The Four Seasons", "Vivaldi", None),
+]
+
+ARTISTS = [
+    "Chris Stapleton",
+    "Rush",
+    "John Mellencamp",
+    "Gov't Mule",
+    "Tantric",
+]
+
+
+def slug(text):
+    s = text.lower()
+    s = re.sub(r'[^a-z0-9]+', '-', s)
+    return s.strip('-')
+
+
+def album_filename(html_title, artist):
+    return f"{slug(artist)}-{slug(html_title)}.jpg"
+
+
+def artist_filename(name):
+    return f"{slug(name)}.jpg"
+
+
+def mb_request(url):
+    req = urllib.request.Request(url, headers={'User-Agent': USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.read()
+    except Exception as e:
+        print(f"    [ERR] {e}")
+        return None
+
+
+def download_url(url, dest):
+    req = urllib.request.Request(url, headers={'User-Agent': USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            data = r.read()
+        if len(data) > 2000:
+            with open(dest, 'wb') as f:
+                f.write(data)
+            return True
+    except Exception as e:
+        print(f"    [ERR] {e}")
+    return False
+
+
+def search_release_mbid(album, artist):
+    """Search MusicBrainz for release, return best-match MBID."""
+    q = urllib.parse.quote(f'release:"{album}" artist:"{artist}"')
+    url = f"https://musicbrainz.org/ws/2/release/?query={q}&limit=5&fmt=json"
+    data = mb_request(url)
+    time.sleep(1.1)
+    if not data:
+        return None
+    try:
+        j = json.loads(data)
+        releases = j.get('releases', [])
+        if releases:
+            return releases[0]['id']
+    except Exception as e:
+        print(f"    [PARSE ERR] {e}")
+    return None
+
+
+def fetch_cover_art(mbid, dest):
+    """Download 250px front cover from Cover Art Archive."""
+    url = f"https://coverartarchive.org/release/{mbid}/front-250"
+    ok = download_url(url, dest)
+    time.sleep(0.5)
+    return ok
+
+
+def fetch_artist_image_wikipedia(name, dest):
+    """Get artist thumbnail from Wikipedia REST API."""
+    title = urllib.parse.quote(name.replace(' ', '_'))
+    url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
+    data = mb_request(url)
+    time.sleep(0.5)
+    if not data:
+        return False
+    try:
+        j = json.loads(data)
+        img_url = j.get('thumbnail', {}).get('source', '')
+        if img_url:
+            return download_url(img_url, dest)
+    except Exception as e:
+        print(f"    [PARSE ERR] {e}")
+    return False
+
+
+def update_html(album_results, artist_results):
+    """
+    Update notable.html: replace SVG placeholder src with downloaded JPG src
+    for each successfully downloaded image.
+    """
+    html_path = os.path.join(BASE_DIR, 'notable.html')
+    with open(html_path, 'r', encoding='utf-8') as f:
+        html = f.read()
+
+    changed = 0
+
+    for html_title, artist, _ in ALBUMS:
+        jpg_fname = album_filename(html_title, artist)
+        if jpg_fname not in album_results:
+            continue
+        svg_src = f"images/albums/{slug(artist)}-{slug(html_title)}.svg"
+        jpg_src = f"images/albums/{jpg_fname}"
+        if svg_src in html:
+            html = html.replace(svg_src, jpg_src, 1)
+            changed += 1
+        elif jpg_src not in html:
+            print(f"  [WARN] No placeholder found for album: {html_title}")
+
+    for name in ARTISTS:
+        jpg_fname = artist_filename(name)
+        if jpg_fname not in artist_results:
+            continue
+        svg_src = f"images/artists/{slug(name)}.svg"
+        jpg_src = f"images/artists/{jpg_fname}"
+        if svg_src in html:
+            html = html.replace(svg_src, jpg_src, 1)
+            changed += 1
+        elif jpg_src not in html:
+            print(f"  [WARN] No placeholder found for artist: {name}")
+
+    with open(html_path, 'w', encoding='utf-8') as f:
+        f.write(html)
+
+    print(f"\nHTML updated: {changed} SVG placeholders replaced with real images.")
+
+
+def main():
+    albums_dir = os.path.join(BASE_DIR, 'images', 'albums')
+    artists_dir = os.path.join(BASE_DIR, 'images', 'artists')
+    os.makedirs(albums_dir, exist_ok=True)
+    os.makedirs(artists_dir, exist_ok=True)
+
+    album_results = set()
+    artist_results = set()
+
+    print("=" * 60)
+    print("PHASE 1: Album Art")
+    print("=" * 60)
+    for html_title, artist, search_title in ALBUMS:
+        fname = album_filename(html_title, artist)
+        dest = os.path.join(albums_dir, fname)
+
+        if os.path.exists(dest):
+            print(f"  [SKIP] {html_title} by {artist}")
+            album_results.add(fname)
+            continue
+
+        search = search_title or html_title
+        print(f"  Searching: {search} by {artist}")
+        mbid = search_release_mbid(search, artist)
+        if mbid:
+            ok = fetch_cover_art(mbid, dest)
+            if ok:
+                print(f"    -> {fname}")
+                album_results.add(fname)
+            else:
+                print(f"    -> no cover art for mbid={mbid}")
+        else:
+            print(f"    -> no MusicBrainz match")
+
+    print()
+    print("=" * 60)
+    print("PHASE 2: Artist Images")
+    print("=" * 60)
+    for name in ARTISTS:
+        fname = artist_filename(name)
+        dest = os.path.join(artists_dir, fname)
+
+        if os.path.exists(dest):
+            print(f"  [SKIP] {name}")
+            artist_results.add(fname)
+            continue
+
+        print(f"  Fetching: {name}")
+        ok = fetch_artist_image_wikipedia(name, dest)
+        if ok:
+            print(f"    -> {fname}")
+            artist_results.add(fname)
+        else:
+            print(f"    -> no image found")
+
+    print()
+    print("=" * 60)
+    print("PHASE 3: Update notable.html")
+    print("=" * 60)
+    update_html(album_results, artist_results)
+
+    print()
+    print(f"Albums downloaded: {len(album_results)}/{len(ALBUMS)}")
+    print(f"Artists downloaded: {len(artist_results)}/{len(ARTISTS)}")
+
+
+if __name__ == '__main__':
+    main()

--- a/generate_placeholder_images.py
+++ b/generate_placeholder_images.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Generate colored SVG placeholder images for albums and artists.
+These serve as fallback art until real images are fetched via fetch_music_images.py.
+
+The SVGs use a deterministic color derived from the name, showing initials.
+"""
+
+import os
+import re
+import hashlib
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Palette of background colors (dark, looks good with white text)
+COLORS = [
+    "#1a1a2e", "#16213e", "#0f3460", "#533483",
+    "#6b2d6b", "#a84b5a", "#c77d5b", "#3a7bd5",
+    "#2b6777", "#2c7873", "#196f3d", "#4a235a",
+    "#784212", "#1b4f72", "#7d6608", "#4a4a4a",
+    "#6e2f2f", "#2e4057", "#048a81", "#54c6eb",
+]
+
+
+def slug(text):
+    s = text.lower()
+    s = re.sub(r'[^a-z0-9]+', '-', s)
+    return s.strip('-')
+
+
+def pick_color(name):
+    h = int(hashlib.md5(name.encode()).hexdigest()[:6], 16)
+    return COLORS[h % len(COLORS)]
+
+
+def initials(name):
+    # Strip leading "The ", "A ", "An " for initials
+    clean = re.sub(r'^(the|a|an)\s+', '', name, flags=re.I)
+    parts = clean.split()
+    if len(parts) >= 2:
+        return (parts[0][0] + parts[-1][0]).upper()
+    elif parts:
+        return parts[0][:2].upper()
+    return "?"
+
+
+def make_svg(label, bg_color, size=250):
+    font_size = size * 0.38
+    cx = size / 2
+    cy = size / 2
+    # Slightly lighter version for subtle gradient
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{size}" height="{size}" viewBox="0 0 {size} {size}">
+  <rect width="{size}" height="{size}" fill="{bg_color}" rx="4"/>
+  <text x="{cx}" y="{cy}" font-family="system-ui, sans-serif" font-size="{font_size:.0f}"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">{label}</text>
+</svg>"""
+
+
+# --- Albums list (html_title, artist) ---
+ALBUMS = [
+    ("Sparkle and Fade", "Everclear"),
+    ("A/B", "Kaleo"),
+    ("Mind Control Acoustic", "Stephen Marley"),
+    ("No Jacket Required", "Phil Collins"),
+    ("Kickin' It", "Hamilton Loomis"),
+    ("Eat Ya Veggies", "bbno$"),
+    ("Freaks of Nature", "Drain STH"),
+    ("Jagged Little Pill", "Alanis Morissette"),
+    ("John Coltrane and Johnny Hartman", "John Coltrane"),
+    ("Greatest Hits", "Steve Miller Band"),
+    ("ZABA", "Glass Animals"),
+    ("A 20 Something Fuck", "Two Feet"),
+    ("The Hits / The B-Sides", "Prince"),
+    ("Don't Explain", "Beth Hart"),
+    ("Mescalito", "Ryan Bingham"),
+    ("Swimming", "Mac Miller"),
+    ("Live at Bonnaroo", "Warren Haynes"),
+    ("Tapestry", "Carole King"),
+    ("The Razors Edge", "AC/DC"),
+    ("Nothing But the Best", "Frank Sinatra"),
+    ("Trouble", "Ray LaMontagne"),
+    ("Facelift", "Alice in Chains"),
+    ("Violator", "Depeche Mode"),
+    ("Nowhere to Hide", "The Virus"),
+    ("Destruction by Definition", "The Suicide Machines"),
+    ("Live at the Old Quarter", "Townes Van Zandt"),
+    ("Moving Pictures", "Rush"),
+    ("2112", "Rush"),
+    ("Retrospective I & II", "Rush"),
+    ("Rock Spectacle", "Barenaked Ladies"),
+    ("Let It Be Me", "Nina Simone"),
+    ("Rainbow", "Kesha"),
+    ("Lie to Me", "Jonny Lang"),
+    ("Live at the Regal", "B.B. King"),
+    ("Who Killed the Zutons", "The Zutons"),
+    ("Heartattack and Vine", "Tom Waits"),
+    ("Hell Freezes Over", "Eagles"),
+    ("Keep 'Em on They Toes", "Brent Cobb"),
+    ("Rage Against the Machine", "Rage Against the Machine"),
+    ("Grace", "Jeff Buckley"),
+    ("The Emancipation of Mimi", "Mariah Carey"),
+    ("Traveller", "Chris Stapleton"),
+    ("Metamodern Sounds in Country Music", "Sturgill Simpson"),
+    ("No Fences", "Garth Brooks"),
+    ("Pieces of You", "Jewel"),
+    ("The Boatman's Call", "Nick Cave and the Bad Seeds"),
+    ("Unplugged", "Eric Clapton"),
+    ("Whitey Ford Sings the Blues", "Everlast"),
+    ("Sublime", "Sublime"),
+    ("Bedtime Stories", "Madonna"),
+    ("Endless Summer Vacation", "Miley Cyrus"),
+    ("Where Have All the Merrymakers Gone?", "Harvey Danger"),
+    ("Metallica (Black Album)", "Metallica"),
+    ("The River", "Bruce Springsteen"),
+    ("Texas Flood", "Stevie Ray Vaughan"),
+    ("No More Tears", "Ozzy Osbourne"),
+    ("Boston", "Boston"),
+    ("Dookie", "Green Day"),
+    ("Give Me Convenience or Give Me Death", "Dead Kennedys"),
+    ("The Four Seasons", "Vivaldi"),
+]
+
+ARTISTS = [
+    "Chris Stapleton",
+    "Rush",
+    "John Mellencamp",
+    "Gov't Mule",
+    "Tantric",
+]
+
+
+def update_html(albums, artists):
+    """Inject item-logo divs into notable.html pointing at SVG placeholders."""
+    html_path = os.path.join(BASE_DIR, 'notable.html')
+    with open(html_path, 'r', encoding='utf-8') as f:
+        html = f.read()
+
+    changed = 0
+
+    for html_title, artist in albums:
+        fname = f"{slug(artist)}-{slug(html_title)}.svg"
+        img_src = f"images/albums/{fname}"
+        alt = f"{html_title} cover"
+        title_escaped = re.escape(html_title)
+        # Only inject if item-logo not already present before this title
+        pattern = (
+            r'(<a href="#" class="notable-item">)'
+            r'(?!\s*<div class="item-logo">)'
+            r'(<div class="item-content">\s*'
+            r'<h3 class="item-title">' + title_escaped + r'</h3>)'
+        )
+        logo = (
+            f'<div class="item-logo">'
+            f'<img src="{img_src}" alt="{alt}" loading="lazy"'
+            f' onerror="this.parentElement.style.display=\'none\'">'
+            f'</div>'
+        )
+        replacement = r'\1' + '\n              ' + logo + r'\2'
+        new_html, n = re.subn(pattern, replacement, html, count=1)
+        if n:
+            html = new_html
+            changed += 1
+        else:
+            # Already has logo or pattern not found — skip silently
+            pass
+
+    for name in artists:
+        fname = f"{slug(name)}.svg"
+        img_src = f"images/artists/{fname}"
+        alt = f"{name} photo"
+        name_escaped = re.escape(name)
+        pattern = (
+            r'(<a href="#" class="notable-item">)'
+            r'(?!\s*<div class="item-logo">)'
+            r'(<div class="item-content">\s*'
+            r'<h3 class="item-title">' + name_escaped + r'</h3>)'
+        )
+        logo = (
+            f'<div class="item-logo">'
+            f'<img src="{img_src}" alt="{alt}" loading="lazy"'
+            f' onerror="this.parentElement.style.display=\'none\'">'
+            f'</div>'
+        )
+        replacement = r'\1' + '\n              ' + logo + r'\2'
+        new_html, n = re.subn(pattern, replacement, html, count=1)
+        if n:
+            html = new_html
+            changed += 1
+
+    with open(html_path, 'w', encoding='utf-8') as f:
+        f.write(html)
+
+    print(f"  notable.html updated: {changed} items injected.")
+
+
+def main():
+    albums_dir = os.path.join(BASE_DIR, 'images', 'albums')
+    artists_dir = os.path.join(BASE_DIR, 'images', 'artists')
+    os.makedirs(albums_dir, exist_ok=True)
+    os.makedirs(artists_dir, exist_ok=True)
+
+    print("Generating album placeholders...")
+    for html_title, artist in ALBUMS:
+        fname = f"{slug(artist)}-{slug(html_title)}.svg"
+        dest = os.path.join(albums_dir, fname)
+        if os.path.exists(dest):
+            print(f"  [SKIP] {fname}")
+            continue
+        label = initials(html_title)
+        color = pick_color(html_title + artist)
+        svg = make_svg(label, color)
+        with open(dest, 'w') as f:
+            f.write(svg)
+        print(f"  {fname}")
+
+    print("\nGenerating artist placeholders...")
+    for name in ARTISTS:
+        fname = f"{slug(name)}.svg"
+        dest = os.path.join(artists_dir, fname)
+        if os.path.exists(dest):
+            print(f"  [SKIP] {fname}")
+            continue
+        label = initials(name)
+        color = pick_color(name)
+        svg = make_svg(label, color)
+        with open(dest, 'w') as f:
+            f.write(svg)
+        print(f"  {fname}")
+
+    print("\nUpdating notable.html...")
+    update_html(ALBUMS, ARTISTS)
+
+    print(f"\nDone. {len(ALBUMS)} album + {len(ARTISTS)} artist placeholders.")
+
+
+if __name__ == '__main__':
+    main()

--- a/images/albums/ac-dc-the-razors-edge.svg
+++ b/images/albums/ac-dc-the-razors-edge.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6b2d6b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RE</text>
+</svg>

--- a/images/albums/alanis-morissette-jagged-little-pill.svg
+++ b/images/albums/alanis-morissette-jagged-little-pill.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#54c6eb" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">JP</text>
+</svg>

--- a/images/albums/alice-in-chains-facelift.svg
+++ b/images/albums/alice-in-chains-facelift.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#0f3460" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">FA</text>
+</svg>

--- a/images/albums/b-b-king-live-at-the-regal.svg
+++ b/images/albums/b-b-king-live-at-the-regal.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#c77d5b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">LR</text>
+</svg>

--- a/images/albums/barenaked-ladies-rock-spectacle.svg
+++ b/images/albums/barenaked-ladies-rock-spectacle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#1b4f72" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RS</text>
+</svg>

--- a/images/albums/bbno-eat-ya-veggies.svg
+++ b/images/albums/bbno-eat-ya-veggies.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">EV</text>
+</svg>

--- a/images/albums/beth-hart-don-t-explain.svg
+++ b/images/albums/beth-hart-don-t-explain.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a235a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">DE</text>
+</svg>

--- a/images/albums/boston-boston.svg
+++ b/images/albums/boston-boston.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">BO</text>
+</svg>

--- a/images/albums/brent-cobb-keep-em-on-they-toes.svg
+++ b/images/albums/brent-cobb-keep-em-on-they-toes.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2b6777" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">KT</text>
+</svg>

--- a/images/albums/bruce-springsteen-the-river.svg
+++ b/images/albums/bruce-springsteen-the-river.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2b6777" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RI</text>
+</svg>

--- a/images/albums/carole-king-tapestry.svg
+++ b/images/albums/carole-king-tapestry.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#1b4f72" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">TA</text>
+</svg>

--- a/images/albums/chris-stapleton-traveller.svg
+++ b/images/albums/chris-stapleton-traveller.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#16213e" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">TR</text>
+</svg>

--- a/images/albums/dead-kennedys-give-me-convenience-or-give-me-death.svg
+++ b/images/albums/dead-kennedys-give-me-convenience-or-give-me-death.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">GD</text>
+</svg>

--- a/images/albums/depeche-mode-violator.svg
+++ b/images/albums/depeche-mode-violator.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#c77d5b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">VI</text>
+</svg>

--- a/images/albums/drain-sth-freaks-of-nature.svg
+++ b/images/albums/drain-sth-freaks-of-nature.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">FN</text>
+</svg>

--- a/images/albums/eagles-hell-freezes-over.svg
+++ b/images/albums/eagles-hell-freezes-over.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6b2d6b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">HO</text>
+</svg>

--- a/images/albums/eric-clapton-unplugged.svg
+++ b/images/albums/eric-clapton-unplugged.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2c7873" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">UN</text>
+</svg>

--- a/images/albums/everclear-sparkle-and-fade.svg
+++ b/images/albums/everclear-sparkle-and-fade.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#7d6608" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">SF</text>
+</svg>

--- a/images/albums/everlast-whitey-ford-sings-the-blues.svg
+++ b/images/albums/everlast-whitey-ford-sings-the-blues.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a4a4a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">WB</text>
+</svg>

--- a/images/albums/frank-sinatra-nothing-but-the-best.svg
+++ b/images/albums/frank-sinatra-nothing-but-the-best.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#533483" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">NB</text>
+</svg>

--- a/images/albums/garth-brooks-no-fences.svg
+++ b/images/albums/garth-brooks-no-fences.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#7d6608" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">NF</text>
+</svg>

--- a/images/albums/glass-animals-zaba.svg
+++ b/images/albums/glass-animals-zaba.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#c77d5b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">ZA</text>
+</svg>

--- a/images/albums/green-day-dookie.svg
+++ b/images/albums/green-day-dookie.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2b6777" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">DO</text>
+</svg>

--- a/images/albums/hamilton-loomis-kickin-it.svg
+++ b/images/albums/hamilton-loomis-kickin-it.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6e2f2f" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">KI</text>
+</svg>

--- a/images/albums/harvey-danger-where-have-all-the-merrymakers-gone.svg
+++ b/images/albums/harvey-danger-where-have-all-the-merrymakers-gone.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a4a4a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">WG</text>
+</svg>

--- a/images/albums/jeff-buckley-grace.svg
+++ b/images/albums/jeff-buckley-grace.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6e2f2f" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">GR</text>
+</svg>

--- a/images/albums/jewel-pieces-of-you.svg
+++ b/images/albums/jewel-pieces-of-you.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#7d6608" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">PY</text>
+</svg>

--- a/images/albums/john-coltrane-john-coltrane-and-johnny-hartman.svg
+++ b/images/albums/john-coltrane-john-coltrane-and-johnny-hartman.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#1b4f72" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">JH</text>
+</svg>

--- a/images/albums/jonny-lang-lie-to-me.svg
+++ b/images/albums/jonny-lang-lie-to-me.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a235a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">LM</text>
+</svg>

--- a/images/albums/kaleo-a-b.svg
+++ b/images/albums/kaleo-a-b.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#c77d5b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">A/</text>
+</svg>

--- a/images/albums/kesha-rainbow.svg
+++ b/images/albums/kesha-rainbow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#196f3d" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RA</text>
+</svg>

--- a/images/albums/mac-miller-swimming.svg
+++ b/images/albums/mac-miller-swimming.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a235a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">SW</text>
+</svg>

--- a/images/albums/madonna-bedtime-stories.svg
+++ b/images/albums/madonna-bedtime-stories.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#3a7bd5" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">BS</text>
+</svg>

--- a/images/albums/mariah-carey-the-emancipation-of-mimi.svg
+++ b/images/albums/mariah-carey-the-emancipation-of-mimi.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">EM</text>
+</svg>

--- a/images/albums/metallica-metallica-black-album.svg
+++ b/images/albums/metallica-metallica-black-album.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#3a7bd5" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">MA</text>
+</svg>

--- a/images/albums/miley-cyrus-endless-summer-vacation.svg
+++ b/images/albums/miley-cyrus-endless-summer-vacation.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#533483" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">EV</text>
+</svg>

--- a/images/albums/nick-cave-and-the-bad-seeds-the-boatman-s-call.svg
+++ b/images/albums/nick-cave-and-the-bad-seeds-the-boatman-s-call.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2c7873" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">BC</text>
+</svg>

--- a/images/albums/nina-simone-let-it-be-me.svg
+++ b/images/albums/nina-simone-let-it-be-me.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2e4057" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">LM</text>
+</svg>

--- a/images/albums/ozzy-osbourne-no-more-tears.svg
+++ b/images/albums/ozzy-osbourne-no-more-tears.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#0f3460" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">NT</text>
+</svg>

--- a/images/albums/phil-collins-no-jacket-required.svg
+++ b/images/albums/phil-collins-no-jacket-required.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#54c6eb" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">NR</text>
+</svg>

--- a/images/albums/prince-the-hits-the-b-sides.svg
+++ b/images/albums/prince-the-hits-the-b-sides.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#3a7bd5" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">HB</text>
+</svg>

--- a/images/albums/rage-against-the-machine-rage-against-the-machine.svg
+++ b/images/albums/rage-against-the-machine-rage-against-the-machine.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#54c6eb" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RM</text>
+</svg>

--- a/images/albums/ray-lamontagne-trouble.svg
+++ b/images/albums/ray-lamontagne-trouble.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a235a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">TR</text>
+</svg>

--- a/images/albums/rush-2112.svg
+++ b/images/albums/rush-2112.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#0f3460" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">21</text>
+</svg>

--- a/images/albums/rush-moving-pictures.svg
+++ b/images/albums/rush-moving-pictures.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6e2f2f" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">MP</text>
+</svg>

--- a/images/albums/rush-retrospective-i-ii.svg
+++ b/images/albums/rush-retrospective-i-ii.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RI</text>
+</svg>

--- a/images/albums/ryan-bingham-mescalito.svg
+++ b/images/albums/ryan-bingham-mescalito.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#3a7bd5" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">ME</text>
+</svg>

--- a/images/albums/stephen-marley-mind-control-acoustic.svg
+++ b/images/albums/stephen-marley-mind-control-acoustic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6b2d6b" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">MA</text>
+</svg>

--- a/images/albums/steve-miller-band-greatest-hits.svg
+++ b/images/albums/steve-miller-band-greatest-hits.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#0f3460" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">GH</text>
+</svg>

--- a/images/albums/stevie-ray-vaughan-texas-flood.svg
+++ b/images/albums/stevie-ray-vaughan-texas-flood.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#4a235a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">TF</text>
+</svg>

--- a/images/albums/sturgill-simpson-metamodern-sounds-in-country-music.svg
+++ b/images/albums/sturgill-simpson-metamodern-sounds-in-country-music.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#0f3460" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">MM</text>
+</svg>

--- a/images/albums/sublime-sublime.svg
+++ b/images/albums/sublime-sublime.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">SU</text>
+</svg>

--- a/images/albums/the-suicide-machines-destruction-by-definition.svg
+++ b/images/albums/the-suicide-machines-destruction-by-definition.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#784212" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">DD</text>
+</svg>

--- a/images/albums/the-virus-nowhere-to-hide.svg
+++ b/images/albums/the-virus-nowhere-to-hide.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2c7873" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">NH</text>
+</svg>

--- a/images/albums/the-zutons-who-killed-the-zutons.svg
+++ b/images/albums/the-zutons-who-killed-the-zutons.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#196f3d" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">WZ</text>
+</svg>

--- a/images/albums/tom-waits-heartattack-and-vine.svg
+++ b/images/albums/tom-waits-heartattack-and-vine.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#16213e" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">HV</text>
+</svg>

--- a/images/albums/townes-van-zandt-live-at-the-old-quarter.svg
+++ b/images/albums/townes-van-zandt-live-at-the-old-quarter.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#1a1a2e" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">LQ</text>
+</svg>

--- a/images/albums/two-feet-a-20-something-fuck.svg
+++ b/images/albums/two-feet-a-20-something-fuck.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#0f3460" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">2F</text>
+</svg>

--- a/images/albums/vivaldi-the-four-seasons.svg
+++ b/images/albums/vivaldi-the-four-seasons.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#54c6eb" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">FS</text>
+</svg>

--- a/images/albums/warren-haynes-live-at-bonnaroo.svg
+++ b/images/albums/warren-haynes-live-at-bonnaroo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2b6777" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">LB</text>
+</svg>

--- a/images/artists/chris-stapleton.svg
+++ b/images/artists/chris-stapleton.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#6e2f2f" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">CS</text>
+</svg>

--- a/images/artists/gov-t-mule.svg
+++ b/images/artists/gov-t-mule.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#16213e" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">GM</text>
+</svg>

--- a/images/artists/john-mellencamp.svg
+++ b/images/artists/john-mellencamp.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#2b6777" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">JM</text>
+</svg>

--- a/images/artists/rush.svg
+++ b/images/artists/rush.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#a84b5a" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">RU</text>
+</svg>

--- a/images/artists/tantric.svg
+++ b/images/artists/tantric.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 250 250">
+  <rect width="250" height="250" fill="#54c6eb" rx="4"/>
+  <text x="125.0" y="125.0" font-family="system-ui, sans-serif" font-size="95"
+    font-weight="700" fill="white" fill-opacity="0.9"
+    text-anchor="middle" dominant-baseline="central">TA</text>
+</svg>

--- a/notable.css
+++ b/notable.css
@@ -293,6 +293,25 @@ body.light-theme .notable-item:hover {
   object-fit: contain;
 }
 
+/* Album/artist cards: stack logo centered on top, text below */
+a.notable-item:has(.item-logo) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+a.notable-item .item-logo {
+  width: 120px;
+  height: 120px;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+a.notable-item .item-logo img {
+  object-fit: cover;
+}
+
 .item-content {
   flex: 1;
   min-width: 0;
@@ -415,6 +434,11 @@ body.light-theme .tag-stable {
     height: 48px;
   }
 
+  a.notable-item .item-logo {
+    width: 96px;
+    height: 96px;
+  }
+
   .item-link {
     padding: 0.6rem 1.2rem;
     font-size: 0.95rem;
@@ -441,6 +465,11 @@ body.light-theme .tag-stable {
   .item-logo {
     width: 40px;
     height: 40px;
+  }
+
+  a.notable-item .item-logo {
+    width: 80px;
+    height: 80px;
   }
 
   .item-title {

--- a/notable.html
+++ b/notable.html
@@ -756,169 +756,197 @@
             <span class="section-title-count">60</span><!-- UPDATE THIS COUNT when adding/removing items -->
           </h2>
           <div class="section-content">
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/everclear-sparkle-and-fade.svg" alt="Sparkle and Fade cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Sparkle and Fade</h3>
                 <p class="item-author">by Everclear</p>
                 <p class="item-category">Alternative Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/kaleo-a-b.svg" alt="A/B cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">A/B</h3>
                 <p class="item-author">by Kaleo</p>
                 <p class="item-category">Blues Rock / Alternative</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/stephen-marley-mind-control-acoustic.svg" alt="Mind Control Acoustic cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Mind Control Acoustic</h3>
                 <p class="item-author">by Stephen Marley</p>
                 <p class="item-category">Reggae / Acoustic</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/phil-collins-no-jacket-required.svg" alt="No Jacket Required cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">No Jacket Required</h3>
                 <p class="item-author">by Phil Collins</p>
                 <p class="item-category">Pop Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/hamilton-loomis-kickin-it.svg" alt="Kickin' It cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Kickin' It</h3>
                 <p class="item-author">by Hamilton Loomis</p>
                 <p class="item-category">Blues</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/bbno-eat-ya-veggies.svg" alt="Eat Ya Veggies cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Eat Ya Veggies</h3>
                 <p class="item-author">by bbno$</p>
                 <p class="item-category">Hip Hop / Pop</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/drain-sth-freaks-of-nature.svg" alt="Freaks of Nature cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Freaks of Nature</h3>
                 <p class="item-author">by Drain STH</p>
                 <p class="item-category">Alternative Metal</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/alanis-morissette-jagged-little-pill.svg" alt="Jagged Little Pill cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Jagged Little Pill</h3>
                 <p class="item-author">by Alanis Morissette</p>
                 <p class="item-category">Alternative Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/john-coltrane-john-coltrane-and-johnny-hartman.svg" alt="John Coltrane and Johnny Hartman cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">John Coltrane and Johnny Hartman</h3>
                 <p class="item-author">by John Coltrane and Johnny Hartman</p>
                 <p class="item-category">Jazz</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/steve-miller-band-greatest-hits.svg" alt="Greatest Hits cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Greatest Hits</h3>
                 <p class="item-author">by Steve Miller Band</p>
                 <p class="item-category">Classic Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/glass-animals-zaba.svg" alt="ZABA cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">ZABA</h3>
                 <p class="item-author">by Glass Animals</p>
                 <p class="item-category">Psychedelic Pop / Indie</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/two-feet-a-20-something-fuck.svg" alt="A 20 Something Fuck cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">A 20 Something Fuck</h3>
                 <p class="item-author">by Two Feet</p>
                 <p class="item-category">Electronic / Blues</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/prince-the-hits-the-b-sides.svg" alt="The Hits / The B-Sides cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">The Hits / The B-Sides</h3>
                 <p class="item-author">by Prince</p>
                 <p class="item-category">Pop / Funk / R&amp;B</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/beth-hart-don-t-explain.svg" alt="Don't Explain cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Don't Explain</h3>
                 <p class="item-author">by Beth Hart and Joe Bonamassa</p>
                 <p class="item-category">Blues / Soul</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/ryan-bingham-mescalito.svg" alt="Mescalito cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Mescalito</h3>
                 <p class="item-author">by Ryan Bingham</p>
                 <p class="item-category">Americana / Country Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/mac-miller-swimming.svg" alt="Swimming cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Swimming</h3>
                 <p class="item-author">by Mac Miller</p>
                 <p class="item-category">Hip Hop / R&amp;B</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/warren-haynes-live-at-bonnaroo.svg" alt="Live at Bonnaroo cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Live at Bonnaroo</h3>
                 <p class="item-author">by Warren Haynes</p>
                 <p class="item-category">Blues Rock / Southern Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/carole-king-tapestry.svg" alt="Tapestry cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Tapestry</h3>
                 <p class="item-author">by Carole King</p>
                 <p class="item-category">Singer-Songwriter / Pop</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/ac-dc-the-razors-edge.svg" alt="The Razors Edge cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">The Razors Edge</h3>
                 <p class="item-author">by AC/DC</p>
                 <p class="item-category">Hard Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/frank-sinatra-nothing-but-the-best.svg" alt="Nothing But the Best cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Nothing But the Best</h3>
                 <p class="item-author">by Frank Sinatra</p>
                 <p class="item-category">Vocal Jazz / Standards</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/ray-lamontagne-trouble.svg" alt="Trouble cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Trouble</h3>
                 <p class="item-author">by Ray LaMontagne</p>
                 <p class="item-category">Folk / Singer-Songwriter</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/alice-in-chains-facelift.svg" alt="Facelift cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Facelift</h3>
                 <p class="item-author">by Alice in Chains</p>
                 <p class="item-category">Grunge / Metal</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/depeche-mode-violator.svg" alt="Violator cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Violator</h3>
                 <p class="item-author">by Depeche Mode</p>
                 <p class="item-category">Synth-Pop / Electronic</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/the-virus-nowhere-to-hide.svg" alt="Nowhere to Hide cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Nowhere to Hide</h3>
                 <p class="item-author">by The Virus</p>
                 <p class="item-category">Street Punk</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/the-suicide-machines-destruction-by-definition.svg" alt="Destruction by Definition cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Destruction by Definition</h3>
                 <p class="item-author">by The Suicide Machines</p>
                 <p class="item-category">Ska Punk</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/townes-van-zandt-live-at-the-old-quarter.svg" alt="Live at the Old Quarter cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Live at the Old Quarter</h3>
                 <p class="item-author">by Townes Van Zandt</p>
                 <p class="item-category">Folk / Country</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/rush-moving-pictures.svg" alt="Moving Pictures cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Moving Pictures</h3>
                 <p class="item-author">by Rush</p>
                 <p class="item-category">Progressive Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/rush-2112.svg" alt="2112 cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">2112</h3>
                 <p class="item-author">by Rush</p>
                 <p class="item-category">Progressive Rock</p>
@@ -930,187 +958,218 @@
                 <p class="item-category">Progressive Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/barenaked-ladies-rock-spectacle.svg" alt="Rock Spectacle cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Rock Spectacle</h3>
                 <p class="item-author">by Barenaked Ladies</p>
                 <p class="item-category">Alternative Rock / Live</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/nina-simone-let-it-be-me.svg" alt="Let It Be Me cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Let It Be Me</h3>
                 <p class="item-author">by Nina Simone</p>
                 <p class="item-category">Jazz / Soul</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/kesha-rainbow.svg" alt="Rainbow cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Rainbow</h3>
                 <p class="item-author">by Kesha</p>
                 <p class="item-category">Pop</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/jonny-lang-lie-to-me.svg" alt="Lie to Me cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Lie to Me</h3>
                 <p class="item-author">by Jonny Lang</p>
                 <p class="item-category">Blues Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/b-b-king-live-at-the-regal.svg" alt="Live at the Regal cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Live at the Regal</h3>
                 <p class="item-author">by B.B. King</p>
                 <p class="item-category">Blues</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/the-zutons-who-killed-the-zutons.svg" alt="Who Killed the Zutons cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Who Killed the Zutons</h3>
                 <p class="item-author">by The Zutons</p>
                 <p class="item-category">Indie Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/tom-waits-heartattack-and-vine.svg" alt="Heartattack and Vine cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Heartattack and Vine</h3>
                 <p class="item-author">by Tom Waits</p>
                 <p class="item-category">Blues Rock / Experimental</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/eagles-hell-freezes-over.svg" alt="Hell Freezes Over cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Hell Freezes Over</h3>
                 <p class="item-author">by Eagles</p>
                 <p class="item-category">Rock / Country Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/brent-cobb-keep-em-on-they-toes.svg" alt="Keep 'Em on They Toes cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Keep 'Em on They Toes</h3>
                 <p class="item-author">by Brent Cobb</p>
                 <p class="item-category">Country / Americana</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/rage-against-the-machine-rage-against-the-machine.svg" alt="Rage Against the Machine cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Rage Against the Machine</h3>
                 <p class="item-author">by Rage Against the Machine</p>
                 <p class="item-category">Rap Metal / Alternative</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/jeff-buckley-grace.svg" alt="Grace cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Grace</h3>
                 <p class="item-author">by Jeff Buckley</p>
                 <p class="item-category">Alternative Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/mariah-carey-the-emancipation-of-mimi.svg" alt="The Emancipation of Mimi cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">The Emancipation of Mimi</h3>
                 <p class="item-author">by Mariah Carey</p>
                 <p class="item-category">R&amp;B / Pop</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/chris-stapleton-traveller.svg" alt="Traveller cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Traveller</h3>
                 <p class="item-author">by Chris Stapleton</p>
                 <p class="item-category">Country / Southern Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/sturgill-simpson-metamodern-sounds-in-country-music.svg" alt="Metamodern Sounds in Country Music cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Metamodern Sounds in Country Music</h3>
                 <p class="item-author">by Sturgill Simpson</p>
                 <p class="item-category">Country / Psychedelic</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/garth-brooks-no-fences.svg" alt="No Fences cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">No Fences</h3>
                 <p class="item-author">by Garth Brooks</p>
                 <p class="item-category">Country</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/jewel-pieces-of-you.svg" alt="Pieces of You cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Pieces of You</h3>
                 <p class="item-author">by Jewel</p>
                 <p class="item-category">Folk / Singer-Songwriter</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/nick-cave-and-the-bad-seeds-the-boatman-s-call.svg" alt="The Boatman's Call cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">The Boatman's Call</h3>
                 <p class="item-author">by Nick Cave and the Bad Seeds</p>
                 <p class="item-category">Alternative / Art Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/eric-clapton-unplugged.svg" alt="Unplugged cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Unplugged</h3>
                 <p class="item-author">by Eric Clapton</p>
                 <p class="item-category">Acoustic / Blues</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/everlast-whitey-ford-sings-the-blues.svg" alt="Whitey Ford Sings the Blues cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Whitey Ford Sings the Blues</h3>
                 <p class="item-author">by Everlast</p>
                 <p class="item-category">Hip Hop / Blues Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/sublime-sublime.svg" alt="Sublime cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Sublime</h3>
                 <p class="item-author">by Sublime</p>
                 <p class="item-category">Ska Punk / Reggae Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/madonna-bedtime-stories.svg" alt="Bedtime Stories cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Bedtime Stories</h3>
                 <p class="item-author">by Madonna</p>
                 <p class="item-category">Pop / R&amp;B</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/miley-cyrus-endless-summer-vacation.svg" alt="Endless Summer Vacation cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Endless Summer Vacation</h3>
                 <p class="item-author">by Miley Cyrus</p>
                 <p class="item-category">Pop / Dance</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/harvey-danger-where-have-all-the-merrymakers-gone.svg" alt="Where Have All the Merrymakers Gone? cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Where Have All the Merrymakers Gone?</h3>
                 <p class="item-author">by Harvey Danger</p>
                 <p class="item-category">Alternative Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/metallica-metallica-black-album.svg" alt="Metallica (Black Album) cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Metallica (Black Album)</h3>
                 <p class="item-author">by Metallica</p>
                 <p class="item-category">Heavy Metal / Hard Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/bruce-springsteen-the-river.svg" alt="The River cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">The River</h3>
                 <p class="item-author">by Bruce Springsteen</p>
                 <p class="item-category">Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/stevie-ray-vaughan-texas-flood.svg" alt="Texas Flood cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Texas Flood</h3>
                 <p class="item-author">by Stevie Ray Vaughan</p>
                 <p class="item-category">Blues Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/ozzy-osbourne-no-more-tears.svg" alt="No More Tears cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">No More Tears</h3>
                 <p class="item-author">by Ozzy Osbourne</p>
                 <p class="item-category">Heavy Metal</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/boston-boston.svg" alt="Boston cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Boston</h3>
                 <p class="item-author">by Boston</p>
                 <p class="item-category">Classic Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/green-day-dookie.svg" alt="Dookie cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Dookie</h3>
                 <p class="item-author">by Green Day</p>
                 <p class="item-category">Pop Punk</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/dead-kennedys-give-me-convenience-or-give-me-death.svg" alt="Give Me Convenience or Give Me Death cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Give Me Convenience or Give Me Death</h3>
                 <p class="item-author">by Dead Kennedys</p>
                 <p class="item-category">Hardcore Punk</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/albums/vivaldi-the-four-seasons.svg" alt="The Four Seasons cover" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">The Four Seasons</h3>
                 <p class="item-author">by Vivaldi</p>
                 <p class="item-category">Classical / Baroque</p>
@@ -1129,27 +1188,32 @@
             <span class="section-title-count">5</span><!-- UPDATE THIS COUNT when adding/removing items -->
           </h2>
           <div class="section-content">
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/artists/chris-stapleton.svg" alt="Chris Stapleton photo" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Chris Stapleton</h3>
                 <p class="item-category">Country / Southern Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/artists/rush.svg" alt="Rush photo" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Rush</h3>
                 <p class="item-category">Progressive Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/artists/john-mellencamp.svg" alt="John Mellencamp photo" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">John Mellencamp</h3>
                 <p class="item-category">Heartland Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/artists/gov-t-mule.svg" alt="Gov't Mule photo" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Gov't Mule</h3>
                 <p class="item-category">Southern Rock / Blues Rock</p>
               </div></a>
 
-            <a href="#" class="notable-item"><div class="item-content">
+            <a href="#" class="notable-item">
+              <div class="item-logo"><img src="images/artists/tantric.svg" alt="Tantric photo" loading="lazy" onerror="this.parentElement.style.display='none'"></div><div class="item-content">
                 <h3 class="item-title">Tantric</h3>
                 <p class="item-category">Post-Grunge / Alternative Rock</p>
               </div></a>


### PR DESCRIPTION
- Generate 60 SVG placeholder thumbnails for all Music Albums (images/albums/)
- Generate 5 SVG placeholder thumbnails for all Music Artists (images/artists/)
- Inject item-logo divs into all album and artist cards in notable.html
  with onerror fallback to hide missing images gracefully
- Add CSS for album/artist card layout: flex-column with image centered
  above text, 120px logo on desktop, scaling down to 96px/80px on mobile
- Add fetch_music_images.py: run locally to replace SVG placeholders with
  real JPEG cover art from MusicBrainz Cover Art Archive + Wikipedia
- Add generate_placeholder_images.py: regenerates SVG placeholders if needed

https://claude.ai/code/session_01RZbiHWx2nQ3ky5pMakQxBT