### PR TITLE
Add Awareness macOS utility to Tools & Services

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -31,7 +31,7 @@
               <span class="section-title-toggle">▼</span>
               <span>Tools & Services</span>
             </span>
-              <span class="section-title-count">10</span><!-- UPDATE THIS COUNT when adding/removing items -->
+              <span class="section-title-count">11</span><!-- UPDATE THIS COUNT when adding/removing items -->
           </h2>
           <div class="section-content">
             <a href="https://dakboard.com/site" class="notable-item" target="_blank" rel="noopener">
@@ -94,6 +94,12 @@
                   <h3 class="item-title">Plex</h3>
                   <p class="item-category">Media Streaming</p>
                   <p class="item-description">Self-hosted media streaming server and client designed for high-quality audio and video playback, simple library management, and easy sharing with friends and family.</p>
+                </div></a>
+
+              <a href="https://reinder.io/awareness/" class="notable-item" target="_blank" rel="noopener"><div class="item-content">
+                  <h3 class="item-title">Awareness</h3>
+                  <p class="item-category">macOS Utility</p>
+                  <p class="item-description">Minimalist menu bar timer for Mac that nudges you to move or take a break every hour. A gentle singing bowl chime reminds you without forced interruptions. Free, privacy-friendly, no tracking.</p>
                 </div></a>
           </div>
         </section>


### PR DESCRIPTION
## Summary
Added Awareness, a minimalist macOS menu bar timer utility, to the Tools & Services section of the notable items list.

## Changes
- Updated the Tools & Services section count from 10 to 11
- Added a new notable item entry for Awareness with:
  - Link to https://reinder.io/awareness/
  - Category: macOS Utility
  - Description highlighting its key features: hourly break reminders, singing bowl chime notifications, free and privacy-friendly

## Details
The new item follows the existing HTML structure and styling conventions used for other notable items in the list. It includes proper accessibility attributes (target="_blank" and rel="noopener") for external links.

https://claude.ai/code/session_019CuyJ7ufAvqhL8t7cKgJwh