### PR TITLE
Add Voice Ink to Tools & Services section

### DIFF
--- a/notable.html
+++ b/notable.html
@@ -32,7 +32,7 @@
               <span class="section-title-toggle">▼</span>
               <span>Tools & Services</span>
             </span>
-              <span class="section-title-count">11</span><!-- UPDATE THIS COUNT when adding/removing items -->
+              <span class="section-title-count">12</span><!-- UPDATE THIS COUNT when adding/removing items -->
           </h2>
           <div class="section-content">
             <a href="https://dakboard.com/site" class="notable-item" target="_blank" rel="noopener">
@@ -101,6 +101,12 @@
                   <h3 class="item-title">Awareness</h3>
                   <p class="item-category">macOS Utility</p>
                   <p class="item-description">Minimalist menu bar timer for Mac that nudges you to move or take a break every hour. A gentle singing bowl chime reminds you without forced interruptions. Free, privacy-friendly, no tracking.</p>
+                </div></a>
+
+              <a href="https://tryvoiceink.com/" class="notable-item" target="_blank" rel="noopener"><div class="item-content">
+                  <h3 class="item-title">Voice Ink</h3>
+                  <p class="item-category">Voice Dictation</p>
+                  <p class="item-description">Fast, private voice-to-text for Mac. Dictate anywhere with a keyboard shortcut, powered by on-device transcription. No subscriptions, no cloud uploads—your words stay on your machine.</p>
                 </div></a>
           </div>
         </section>


### PR DESCRIPTION
## Summary
Added Voice Ink, a voice-to-text dictation tool, to the Tools & Services section of the notable items list.

## Changes
- Updated the Tools & Services count from 11 to 12
- Added a new notable item entry for Voice Ink with:
  - Link to https://tryvoiceink.com/
  - Category: Voice Dictation
  - Description highlighting its privacy-focused, on-device transcription features and keyboard shortcut accessibility

## Details
Voice Ink is positioned as a privacy-friendly alternative for voice dictation on macOS, emphasizing its local processing and lack of cloud uploads or subscriptions.

https://claude.ai/code/session_011wZsdezUWuVe8Fe6Zhnt3P